### PR TITLE
fix: Get user roles by using brain user entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "hubot-kubernetes",
   "description": "Hubot Kubernetes integration",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Can Yucel (https://github.com/canthefason)",
+  "contributors": [
+    "Tommi Laukkanen (https://github.com/tlaukkanen)"
+  ],
   "license": "MIT",
   "keywords": [
     "hubot",

--- a/src/kubernetes.coffee
+++ b/src/kubernetes.coffee
@@ -85,7 +85,8 @@ module.exports = (robot) ->
     if res.match[2] and res.match[2] != ""
       url += "?labelSelector=#{res.match[2].trim()}"
 
-    roles = robot.auth.userRoles res.envelope.user
+    userFromBrain = robot.brain.userForName(res.message.user.name)
+    roles = robot.auth.userRoles userFromBrain
     kubeapi.get {path: url, roles}, (err, response) ->
       if err
         robot.logger.error err


### PR DESCRIPTION
Happy Hacktoberfest @canthefason :)

Tried to use the module with latest [hubot-slack](https://github.com/slackapi/hubot-slack) 4.x and [hubot-auth](https://github.com/hubot-scripts/hubot-auth) 2.1.x and the res.envelope.user object didn't include the user roles so the role mapping from tokenMap didn't work out.

This change switches the retrieval of user roles to use similar piece of code that's in _hubot-auth_ when user does the _"what roles do I have"_. With this change I was able to get the correct roles for the API call from the brain for hubot-auth.