### PR TITLE
feat: Bearer token authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Finally, run `npm install hubot-kubernetes` and you're done!
 - KUBE_CONTEXT - (OPTIONAL) Default namespace for the queries. (By default: default)
 - KUBE_VERSION - (OPTIONAL) Your Kubernetes api version. (By default: v1)
 - KUBE_TOKENS - (See Supporting different k8s users section)
+- KUBE_AUTH_TYPE - (OPTIONAL) Kubernetes authentication type, basic and bearer supported. (By default: basic)
 
 #### Self Signed Certificates
 For https connections, you need to set one of the following environment variables:

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "hubot-kubernetes",
   "description": "Hubot Kubernetes integration",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Can Yucel (https://github.com/canthefason)",
+  "contributors": [
+    "Tommi Laukkanen (https://github.com/tlaukkanen)"
+  ],
   "license": "MIT",
   "keywords": [
     "hubot",

--- a/src/kubernetes.coffee
+++ b/src/kubernetes.coffee
@@ -10,6 +10,7 @@
 #   KUBE_CONTEXT
 #   KUBE_CA
 #   KUBE_TOKENS
+#   KUBE_AUTH_TYPE
 #
 # Commands:
 #   hubot k8s [po|rc|svc] (labels) - List all k8s resources under given context
@@ -155,10 +156,15 @@ class Request
 
     authOptions = {}
     user = @getKubeUser roles
+    authType = process.env.KUBE_AUTH_TYPE
     if user and user isnt ""
-      requestOptions['auth'] =
-        user: user
-        pass: @tokenMap[user]
+      if authType and authType is "bearer"
+        requestOptions['auth'] =
+          bearer: @tokenMap[user]
+      else if not authType or authType is "" or authType is "basic"
+        requestOptions['auth'] =
+          user: user
+          pass: @tokenMap[user]
 
     request.get requestOptions, (err, response, data) ->
 


### PR DESCRIPTION
Adds [bearer token](https://kubernetes.io/docs/admin/authentication/#static-token-file) support for Kubernetes API calls based based on the same tokenMap configuration.

This is downwards compatible change as it still defaults to basic authentication if `KUBE_AUTH_TYPE` is not defined.